### PR TITLE
Cookie path query

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,7 +26,7 @@ plugins {
     `maven-publish`
 }
 
-val jUnitVersion = "5.6.0"
+val jUnitVersion = "5.6.2"
 
 subprojects {
     apply(plugin = "kotlin")

--- a/docs/dependencies/hurl-cli.txt
+++ b/docs/dependencies/hurl-cli.txt
@@ -23,7 +23,7 @@ No dependencies
 apiElements - API elements for main. (n)
 No dependencies
 
-archives - Configuration for archive artifacts.
+archives - Configuration for archive artifacts. (n)
 No dependencies
 
 compileClasspath - Compile classpath for compilation 'main' (target  (jvm)).
@@ -44,32 +44,8 @@ No dependencies
 compileOnlyDependenciesMetadata
 No dependencies
 
-default - Configuration for default artifacts.
-+--- project :hurl-core
-|    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.4.0
-|    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.4.0
-|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.4.0
-|    |    |    \--- org.jetbrains:annotations:13.0
-|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.4.0
-|    |         \--- org.jetbrains.kotlin:kotlin-stdlib:1.4.0 (*)
-|    +--- com.fasterxml.jackson.core:jackson-core:2.11.2
-|    +--- org.jsoup:jsoup:1.12.2
-|    +--- com.jayway.jsonpath:json-path:2.4.0
-|    |    +--- net.minidev:json-smart:2.3
-|    |    |    \--- net.minidev:accessors-smart:1.2
-|    |    |         \--- org.ow2.asm:asm:5.0.4
-|    |    \--- org.slf4j:slf4j-api:1.7.25 -> 1.7.30
-|    +--- org.apache.httpcomponents:httpclient:4.5.12
-|    |    +--- org.apache.httpcomponents:httpcore:4.4.13
-|    |    +--- commons-logging:commons-logging:1.2
-|    |    \--- commons-codec:commons-codec:1.11
-|    +--- org.apache.httpcomponents:httpmime:4.5.12
-|    |    \--- org.apache.httpcomponents:httpclient:4.5.12 (*)
-|    \--- org.slf4j:slf4j-api:1.7.30
-+--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.4.0 (*)
-+--- commons-cli:commons-cli:1.4
-\--- org.slf4j:slf4j-jdk14:1.7.29
-     \--- org.slf4j:slf4j-api:1.7.29 -> 1.7.30
+default - Configuration for default artifacts. (n)
+No dependencies
 
 implementation - Implementation only dependencies for compilation 'main' (target  (jvm)). (n)
 +--- project hurl-core (n)
@@ -203,25 +179,25 @@ testCompileClasspath - Compile classpath for compilation 'test' (target  (jvm)).
 |    +--- org.jetbrains.kotlin:kotlin-test-common:1.4.0
 |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.4.0
 |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.4.0 (*)
-\--- org.junit.jupiter:junit-jupiter-engine:5.6.0
-     +--- org.junit:junit-bom:5.6.0
-     |    +--- org.junit.jupiter:junit-jupiter-api:5.6.0 (c)
-     |    +--- org.junit.jupiter:junit-jupiter-engine:5.6.0 (c)
-     |    +--- org.junit.platform:junit-platform-engine:1.6.0 (c)
-     |    \--- org.junit.platform:junit-platform-commons:1.6.0 (c)
+\--- org.junit.jupiter:junit-jupiter-engine:5.6.2
+     +--- org.junit:junit-bom:5.6.2
+     |    +--- org.junit.jupiter:junit-jupiter-api:5.6.2 (c)
+     |    +--- org.junit.jupiter:junit-jupiter-engine:5.6.2 (c)
+     |    +--- org.junit.platform:junit-platform-engine:1.6.2 (c)
+     |    \--- org.junit.platform:junit-platform-commons:1.6.2 (c)
      +--- org.apiguardian:apiguardian-api:1.1.0
-     +--- org.junit.platform:junit-platform-engine:1.6.0
-     |    +--- org.junit:junit-bom:5.6.0 (*)
+     +--- org.junit.platform:junit-platform-engine:1.6.2
+     |    +--- org.junit:junit-bom:5.6.2 (*)
      |    +--- org.apiguardian:apiguardian-api:1.1.0
      |    +--- org.opentest4j:opentest4j:1.2.0
-     |    \--- org.junit.platform:junit-platform-commons:1.6.0
-     |         +--- org.junit:junit-bom:5.6.0 (*)
+     |    \--- org.junit.platform:junit-platform-commons:1.6.2
+     |         +--- org.junit:junit-bom:5.6.2 (*)
      |         \--- org.apiguardian:apiguardian-api:1.1.0
-     \--- org.junit.jupiter:junit-jupiter-api:5.6.0
-          +--- org.junit:junit-bom:5.6.0 (*)
+     \--- org.junit.jupiter:junit-jupiter-api:5.6.2
+          +--- org.junit:junit-bom:5.6.2 (*)
           +--- org.apiguardian:apiguardian-api:1.1.0
           +--- org.opentest4j:opentest4j:1.2.0
-          \--- org.junit.platform:junit-platform-commons:1.6.0 (*)
+          \--- org.junit.platform:junit-platform-commons:1.6.2 (*)
 
 testCompileOnly - Compile only dependencies for compilation 'test' (target  (jvm)). (n)
 No dependencies
@@ -231,7 +207,7 @@ No dependencies
 
 testImplementation - Implementation only dependencies for compilation 'test' (target  (jvm)). (n)
 +--- org.jetbrains.kotlin:kotlin-test:1.4.0 (n)
-\--- org.junit.jupiter:junit-jupiter-engine:5.6.0 (n)
+\--- org.junit.jupiter:junit-jupiter-engine:5.6.2 (n)
 
 testImplementationDependenciesMetadata
 +--- project :hurl-core
@@ -248,25 +224,25 @@ testImplementationDependenciesMetadata
 |    +--- org.jetbrains.kotlin:kotlin-test-common:1.4.0
 |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.4.0
 |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.4.0 (*)
-\--- org.junit.jupiter:junit-jupiter-engine:5.6.0
-     +--- org.junit:junit-bom:5.6.0
-     |    +--- org.junit.jupiter:junit-jupiter-api:5.6.0 (c)
-     |    +--- org.junit.jupiter:junit-jupiter-engine:5.6.0 (c)
-     |    +--- org.junit.platform:junit-platform-engine:1.6.0 (c)
-     |    \--- org.junit.platform:junit-platform-commons:1.6.0 (c)
+\--- org.junit.jupiter:junit-jupiter-engine:5.6.2
+     +--- org.junit:junit-bom:5.6.2
+     |    +--- org.junit.jupiter:junit-jupiter-api:5.6.2 (c)
+     |    +--- org.junit.jupiter:junit-jupiter-engine:5.6.2 (c)
+     |    +--- org.junit.platform:junit-platform-engine:1.6.2 (c)
+     |    \--- org.junit.platform:junit-platform-commons:1.6.2 (c)
      +--- org.apiguardian:apiguardian-api:1.1.0
-     +--- org.junit.platform:junit-platform-engine:1.6.0
-     |    +--- org.junit:junit-bom:5.6.0 (*)
+     +--- org.junit.platform:junit-platform-engine:1.6.2
+     |    +--- org.junit:junit-bom:5.6.2 (*)
      |    +--- org.apiguardian:apiguardian-api:1.1.0
      |    +--- org.opentest4j:opentest4j:1.2.0
-     |    \--- org.junit.platform:junit-platform-commons:1.6.0
-     |         +--- org.junit:junit-bom:5.6.0 (*)
+     |    \--- org.junit.platform:junit-platform-commons:1.6.2
+     |         +--- org.junit:junit-bom:5.6.2 (*)
      |         \--- org.apiguardian:apiguardian-api:1.1.0
-     \--- org.junit.jupiter:junit-jupiter-api:5.6.0
-          +--- org.junit:junit-bom:5.6.0 (*)
+     \--- org.junit.jupiter:junit-jupiter-api:5.6.2
+          +--- org.junit:junit-bom:5.6.2 (*)
           +--- org.apiguardian:apiguardian-api:1.1.0
           +--- org.opentest4j:opentest4j:1.2.0
-          \--- org.junit.platform:junit-platform-commons:1.6.0 (*)
+          \--- org.junit.platform:junit-platform-commons:1.6.2 (*)
 
 testKotlinScriptDef - Script filename extensions discovery classpath configuration
 No dependencies
@@ -304,25 +280,25 @@ testRuntimeClasspath - Runtime classpath of compilation 'test' (target  (jvm)).
 |    +--- org.jetbrains.kotlin:kotlin-test-common:1.4.0
 |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.4.0
 |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.4.0 (*)
-\--- org.junit.jupiter:junit-jupiter-engine:5.6.0
-     +--- org.junit:junit-bom:5.6.0
-     |    +--- org.junit.jupiter:junit-jupiter-api:5.6.0 (c)
-     |    +--- org.junit.jupiter:junit-jupiter-engine:5.6.0 (c)
-     |    +--- org.junit.platform:junit-platform-engine:1.6.0 (c)
-     |    \--- org.junit.platform:junit-platform-commons:1.6.0 (c)
+\--- org.junit.jupiter:junit-jupiter-engine:5.6.2
+     +--- org.junit:junit-bom:5.6.2
+     |    +--- org.junit.jupiter:junit-jupiter-api:5.6.2 (c)
+     |    +--- org.junit.jupiter:junit-jupiter-engine:5.6.2 (c)
+     |    +--- org.junit.platform:junit-platform-engine:1.6.2 (c)
+     |    \--- org.junit.platform:junit-platform-commons:1.6.2 (c)
      +--- org.apiguardian:apiguardian-api:1.1.0
-     +--- org.junit.platform:junit-platform-engine:1.6.0
-     |    +--- org.junit:junit-bom:5.6.0 (*)
+     +--- org.junit.platform:junit-platform-engine:1.6.2
+     |    +--- org.junit:junit-bom:5.6.2 (*)
      |    +--- org.apiguardian:apiguardian-api:1.1.0
      |    +--- org.opentest4j:opentest4j:1.2.0
-     |    \--- org.junit.platform:junit-platform-commons:1.6.0
-     |         +--- org.junit:junit-bom:5.6.0 (*)
+     |    \--- org.junit.platform:junit-platform-commons:1.6.2
+     |         +--- org.junit:junit-bom:5.6.2 (*)
      |         \--- org.apiguardian:apiguardian-api:1.1.0
-     \--- org.junit.jupiter:junit-jupiter-api:5.6.0
-          +--- org.junit:junit-bom:5.6.0 (*)
+     \--- org.junit.jupiter:junit-jupiter-api:5.6.2
+          +--- org.junit:junit-bom:5.6.2 (*)
           +--- org.apiguardian:apiguardian-api:1.1.0
           +--- org.opentest4j:opentest4j:1.2.0
-          \--- org.junit.platform:junit-platform-commons:1.6.0 (*)
+          \--- org.junit.platform:junit-platform-commons:1.6.2 (*)
 
 testRuntimeOnly - Runtime only dependencies for compilation 'test' (target  (jvm)). (n)
 No dependencies
@@ -337,5 +313,5 @@ No dependencies
 
 A web-based, searchable dependency report is available by adding the --scan option.
 
-BUILD SUCCESSFUL in 2s
+BUILD SUCCESSFUL in 723ms
 1 actionable task: 1 executed

--- a/docs/dependencies/hurl-core.txt
+++ b/docs/dependencies/hurl-core.txt
@@ -23,7 +23,7 @@ No dependencies
 apiElements - API elements for main. (n)
 No dependencies
 
-archives - Configuration for archive artifacts.
+archives - Configuration for archive artifacts. (n)
 No dependencies
 
 compileClasspath - Compile classpath for compilation 'main' (target  (jvm)).
@@ -54,27 +54,8 @@ No dependencies
 compileOnlyDependenciesMetadata
 No dependencies
 
-default - Configuration for default artifacts.
-+--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.4.0
-|    +--- org.jetbrains.kotlin:kotlin-stdlib:1.4.0
-|    |    +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.4.0
-|    |    \--- org.jetbrains:annotations:13.0
-|    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.4.0
-|         \--- org.jetbrains.kotlin:kotlin-stdlib:1.4.0 (*)
-+--- com.fasterxml.jackson.core:jackson-core:2.11.2
-+--- org.jsoup:jsoup:1.12.2
-+--- com.jayway.jsonpath:json-path:2.4.0
-|    +--- net.minidev:json-smart:2.3
-|    |    \--- net.minidev:accessors-smart:1.2
-|    |         \--- org.ow2.asm:asm:5.0.4
-|    \--- org.slf4j:slf4j-api:1.7.25 -> 1.7.30
-+--- org.apache.httpcomponents:httpclient:4.5.12
-|    +--- org.apache.httpcomponents:httpcore:4.4.13
-|    +--- commons-logging:commons-logging:1.2
-|    \--- commons-codec:commons-codec:1.11
-+--- org.apache.httpcomponents:httpmime:4.5.12
-|    \--- org.apache.httpcomponents:httpclient:4.5.12 (*)
-\--- org.slf4j:slf4j-api:1.7.30
+default - Configuration for default artifacts. (n)
+No dependencies
 
 implementation - Implementation only dependencies for compilation 'main' (target  (jvm)). (n)
 +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.4.0 (n)
@@ -244,25 +225,25 @@ testCompileClasspath - Compile classpath for compilation 'test' (target  (jvm)).
 |    +--- org.jetbrains.kotlin:kotlin-test-common:1.4.0
 |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.4.0
 |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.4.0 (*)
-+--- org.junit.jupiter:junit-jupiter-engine:5.6.0
-|    +--- org.junit:junit-bom:5.6.0
-|    |    +--- org.junit.jupiter:junit-jupiter-api:5.6.0 (c)
-|    |    +--- org.junit.jupiter:junit-jupiter-engine:5.6.0 (c)
-|    |    +--- org.junit.platform:junit-platform-engine:1.6.0 (c)
-|    |    \--- org.junit.platform:junit-platform-commons:1.6.0 (c)
++--- org.junit.jupiter:junit-jupiter-engine:5.6.2
+|    +--- org.junit:junit-bom:5.6.2
+|    |    +--- org.junit.jupiter:junit-jupiter-api:5.6.2 (c)
+|    |    +--- org.junit.jupiter:junit-jupiter-engine:5.6.2 (c)
+|    |    +--- org.junit.platform:junit-platform-engine:1.6.2 (c)
+|    |    \--- org.junit.platform:junit-platform-commons:1.6.2 (c)
 |    +--- org.apiguardian:apiguardian-api:1.1.0
-|    +--- org.junit.platform:junit-platform-engine:1.6.0
-|    |    +--- org.junit:junit-bom:5.6.0 (*)
+|    +--- org.junit.platform:junit-platform-engine:1.6.2
+|    |    +--- org.junit:junit-bom:5.6.2 (*)
 |    |    +--- org.apiguardian:apiguardian-api:1.1.0
 |    |    +--- org.opentest4j:opentest4j:1.2.0
-|    |    \--- org.junit.platform:junit-platform-commons:1.6.0
-|    |         +--- org.junit:junit-bom:5.6.0 (*)
+|    |    \--- org.junit.platform:junit-platform-commons:1.6.2
+|    |         +--- org.junit:junit-bom:5.6.2 (*)
 |    |         \--- org.apiguardian:apiguardian-api:1.1.0
-|    \--- org.junit.jupiter:junit-jupiter-api:5.6.0
-|         +--- org.junit:junit-bom:5.6.0 (*)
+|    \--- org.junit.jupiter:junit-jupiter-api:5.6.2
+|         +--- org.junit:junit-bom:5.6.2 (*)
 |         +--- org.apiguardian:apiguardian-api:1.1.0
 |         +--- org.opentest4j:opentest4j:1.2.0
-|         \--- org.junit.platform:junit-platform-commons:1.6.0 (*)
+|         \--- org.junit.platform:junit-platform-commons:1.6.2 (*)
 \--- org.slf4j:slf4j-nop:1.7.30
      \--- org.slf4j:slf4j-api:1.7.30
 
@@ -274,7 +255,7 @@ No dependencies
 
 testImplementation - Implementation only dependencies for compilation 'test' (target  (jvm)). (n)
 +--- org.jetbrains.kotlin:kotlin-test:1.4.0 (n)
-+--- org.junit.jupiter:junit-jupiter-engine:5.6.0 (n)
++--- org.junit.jupiter:junit-jupiter-engine:5.6.2 (n)
 \--- org.slf4j:slf4j-nop:1.7.30 (n)
 
 testImplementationDependenciesMetadata
@@ -302,25 +283,25 @@ testImplementationDependenciesMetadata
 |    +--- org.jetbrains.kotlin:kotlin-test-common:1.4.0
 |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.4.0
 |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.4.0 (*)
-+--- org.junit.jupiter:junit-jupiter-engine:5.6.0
-|    +--- org.junit:junit-bom:5.6.0
-|    |    +--- org.junit.jupiter:junit-jupiter-api:5.6.0 (c)
-|    |    +--- org.junit.jupiter:junit-jupiter-engine:5.6.0 (c)
-|    |    +--- org.junit.platform:junit-platform-engine:1.6.0 (c)
-|    |    \--- org.junit.platform:junit-platform-commons:1.6.0 (c)
++--- org.junit.jupiter:junit-jupiter-engine:5.6.2
+|    +--- org.junit:junit-bom:5.6.2
+|    |    +--- org.junit.jupiter:junit-jupiter-api:5.6.2 (c)
+|    |    +--- org.junit.jupiter:junit-jupiter-engine:5.6.2 (c)
+|    |    +--- org.junit.platform:junit-platform-engine:1.6.2 (c)
+|    |    \--- org.junit.platform:junit-platform-commons:1.6.2 (c)
 |    +--- org.apiguardian:apiguardian-api:1.1.0
-|    +--- org.junit.platform:junit-platform-engine:1.6.0
-|    |    +--- org.junit:junit-bom:5.6.0 (*)
+|    +--- org.junit.platform:junit-platform-engine:1.6.2
+|    |    +--- org.junit:junit-bom:5.6.2 (*)
 |    |    +--- org.apiguardian:apiguardian-api:1.1.0
 |    |    +--- org.opentest4j:opentest4j:1.2.0
-|    |    \--- org.junit.platform:junit-platform-commons:1.6.0
-|    |         +--- org.junit:junit-bom:5.6.0 (*)
+|    |    \--- org.junit.platform:junit-platform-commons:1.6.2
+|    |         +--- org.junit:junit-bom:5.6.2 (*)
 |    |         \--- org.apiguardian:apiguardian-api:1.1.0
-|    \--- org.junit.jupiter:junit-jupiter-api:5.6.0
-|         +--- org.junit:junit-bom:5.6.0 (*)
+|    \--- org.junit.jupiter:junit-jupiter-api:5.6.2
+|         +--- org.junit:junit-bom:5.6.2 (*)
 |         +--- org.apiguardian:apiguardian-api:1.1.0
 |         +--- org.opentest4j:opentest4j:1.2.0
-|         \--- org.junit.platform:junit-platform-commons:1.6.0 (*)
+|         \--- org.junit.platform:junit-platform-commons:1.6.2 (*)
 \--- org.slf4j:slf4j-nop:1.7.30
      \--- org.slf4j:slf4j-api:1.7.30
 
@@ -355,25 +336,25 @@ testRuntimeClasspath - Runtime classpath of compilation 'test' (target  (jvm)).
 |    +--- org.jetbrains.kotlin:kotlin-test-common:1.4.0
 |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.4.0
 |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.4.0 (*)
-+--- org.junit.jupiter:junit-jupiter-engine:5.6.0
-|    +--- org.junit:junit-bom:5.6.0
-|    |    +--- org.junit.jupiter:junit-jupiter-api:5.6.0 (c)
-|    |    +--- org.junit.jupiter:junit-jupiter-engine:5.6.0 (c)
-|    |    +--- org.junit.platform:junit-platform-engine:1.6.0 (c)
-|    |    \--- org.junit.platform:junit-platform-commons:1.6.0 (c)
++--- org.junit.jupiter:junit-jupiter-engine:5.6.2
+|    +--- org.junit:junit-bom:5.6.2
+|    |    +--- org.junit.jupiter:junit-jupiter-api:5.6.2 (c)
+|    |    +--- org.junit.jupiter:junit-jupiter-engine:5.6.2 (c)
+|    |    +--- org.junit.platform:junit-platform-engine:1.6.2 (c)
+|    |    \--- org.junit.platform:junit-platform-commons:1.6.2 (c)
 |    +--- org.apiguardian:apiguardian-api:1.1.0
-|    +--- org.junit.platform:junit-platform-engine:1.6.0
-|    |    +--- org.junit:junit-bom:5.6.0 (*)
+|    +--- org.junit.platform:junit-platform-engine:1.6.2
+|    |    +--- org.junit:junit-bom:5.6.2 (*)
 |    |    +--- org.apiguardian:apiguardian-api:1.1.0
 |    |    +--- org.opentest4j:opentest4j:1.2.0
-|    |    \--- org.junit.platform:junit-platform-commons:1.6.0
-|    |         +--- org.junit:junit-bom:5.6.0 (*)
+|    |    \--- org.junit.platform:junit-platform-commons:1.6.2
+|    |         +--- org.junit:junit-bom:5.6.2 (*)
 |    |         \--- org.apiguardian:apiguardian-api:1.1.0
-|    \--- org.junit.jupiter:junit-jupiter-api:5.6.0
-|         +--- org.junit:junit-bom:5.6.0 (*)
+|    \--- org.junit.jupiter:junit-jupiter-api:5.6.2
+|         +--- org.junit:junit-bom:5.6.2 (*)
 |         +--- org.apiguardian:apiguardian-api:1.1.0
 |         +--- org.opentest4j:opentest4j:1.2.0
-|         \--- org.junit.platform:junit-platform-commons:1.6.0 (*)
+|         \--- org.junit.platform:junit-platform-commons:1.6.2 (*)
 \--- org.slf4j:slf4j-nop:1.7.30
      \--- org.slf4j:slf4j-api:1.7.30
 
@@ -390,5 +371,5 @@ No dependencies
 
 A web-based, searchable dependency report is available by adding the --scan option.
 
-BUILD SUCCESSFUL in 20s
+BUILD SUCCESSFUL in 3s
 1 actionable task: 1 executed

--- a/docs/dependencies/hurl-fmt.txt
+++ b/docs/dependencies/hurl-fmt.txt
@@ -23,7 +23,7 @@ No dependencies
 apiElements - API elements for main. (n)
 No dependencies
 
-archives - Configuration for archive artifacts.
+archives - Configuration for archive artifacts. (n)
 No dependencies
 
 compileClasspath - Compile classpath for compilation 'main' (target  (jvm)).
@@ -44,32 +44,8 @@ No dependencies
 compileOnlyDependenciesMetadata
 No dependencies
 
-default - Configuration for default artifacts.
-+--- project :hurl-core
-|    +--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.4.0
-|    |    +--- org.jetbrains.kotlin:kotlin-stdlib:1.4.0
-|    |    |    +--- org.jetbrains.kotlin:kotlin-stdlib-common:1.4.0
-|    |    |    \--- org.jetbrains:annotations:13.0
-|    |    \--- org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.4.0
-|    |         \--- org.jetbrains.kotlin:kotlin-stdlib:1.4.0 (*)
-|    +--- com.fasterxml.jackson.core:jackson-core:2.11.2
-|    +--- org.jsoup:jsoup:1.12.2
-|    +--- com.jayway.jsonpath:json-path:2.4.0
-|    |    +--- net.minidev:json-smart:2.3
-|    |    |    \--- net.minidev:accessors-smart:1.2
-|    |    |         \--- org.ow2.asm:asm:5.0.4
-|    |    \--- org.slf4j:slf4j-api:1.7.25 -> 1.7.30
-|    +--- org.apache.httpcomponents:httpclient:4.5.12
-|    |    +--- org.apache.httpcomponents:httpcore:4.4.13
-|    |    +--- commons-logging:commons-logging:1.2
-|    |    \--- commons-codec:commons-codec:1.11
-|    +--- org.apache.httpcomponents:httpmime:4.5.12
-|    |    \--- org.apache.httpcomponents:httpclient:4.5.12 (*)
-|    \--- org.slf4j:slf4j-api:1.7.30
-+--- org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.4.0 (*)
-+--- commons-cli:commons-cli:1.4
-\--- org.slf4j:slf4j-jdk14:1.7.29
-     \--- org.slf4j:slf4j-api:1.7.29 -> 1.7.30
+default - Configuration for default artifacts. (n)
+No dependencies
 
 implementation - Implementation only dependencies for compilation 'main' (target  (jvm)). (n)
 +--- project hurl-core (n)
@@ -203,25 +179,25 @@ testCompileClasspath - Compile classpath for compilation 'test' (target  (jvm)).
 |    +--- org.jetbrains.kotlin:kotlin-test-common:1.4.0
 |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.4.0
 |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.4.0 (*)
-\--- org.junit.jupiter:junit-jupiter-engine:5.6.0
-     +--- org.junit:junit-bom:5.6.0
-     |    +--- org.junit.jupiter:junit-jupiter-api:5.6.0 (c)
-     |    +--- org.junit.jupiter:junit-jupiter-engine:5.6.0 (c)
-     |    +--- org.junit.platform:junit-platform-engine:1.6.0 (c)
-     |    \--- org.junit.platform:junit-platform-commons:1.6.0 (c)
+\--- org.junit.jupiter:junit-jupiter-engine:5.6.2
+     +--- org.junit:junit-bom:5.6.2
+     |    +--- org.junit.jupiter:junit-jupiter-api:5.6.2 (c)
+     |    +--- org.junit.jupiter:junit-jupiter-engine:5.6.2 (c)
+     |    +--- org.junit.platform:junit-platform-engine:1.6.2 (c)
+     |    \--- org.junit.platform:junit-platform-commons:1.6.2 (c)
      +--- org.apiguardian:apiguardian-api:1.1.0
-     +--- org.junit.platform:junit-platform-engine:1.6.0
-     |    +--- org.junit:junit-bom:5.6.0 (*)
+     +--- org.junit.platform:junit-platform-engine:1.6.2
+     |    +--- org.junit:junit-bom:5.6.2 (*)
      |    +--- org.apiguardian:apiguardian-api:1.1.0
      |    +--- org.opentest4j:opentest4j:1.2.0
-     |    \--- org.junit.platform:junit-platform-commons:1.6.0
-     |         +--- org.junit:junit-bom:5.6.0 (*)
+     |    \--- org.junit.platform:junit-platform-commons:1.6.2
+     |         +--- org.junit:junit-bom:5.6.2 (*)
      |         \--- org.apiguardian:apiguardian-api:1.1.0
-     \--- org.junit.jupiter:junit-jupiter-api:5.6.0
-          +--- org.junit:junit-bom:5.6.0 (*)
+     \--- org.junit.jupiter:junit-jupiter-api:5.6.2
+          +--- org.junit:junit-bom:5.6.2 (*)
           +--- org.apiguardian:apiguardian-api:1.1.0
           +--- org.opentest4j:opentest4j:1.2.0
-          \--- org.junit.platform:junit-platform-commons:1.6.0 (*)
+          \--- org.junit.platform:junit-platform-commons:1.6.2 (*)
 
 testCompileOnly - Compile only dependencies for compilation 'test' (target  (jvm)). (n)
 No dependencies
@@ -231,7 +207,7 @@ No dependencies
 
 testImplementation - Implementation only dependencies for compilation 'test' (target  (jvm)). (n)
 +--- org.jetbrains.kotlin:kotlin-test:1.4.0 (n)
-\--- org.junit.jupiter:junit-jupiter-engine:5.6.0 (n)
+\--- org.junit.jupiter:junit-jupiter-engine:5.6.2 (n)
 
 testImplementationDependenciesMetadata
 +--- project :hurl-core
@@ -248,25 +224,25 @@ testImplementationDependenciesMetadata
 |    +--- org.jetbrains.kotlin:kotlin-test-common:1.4.0
 |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.4.0
 |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.4.0 (*)
-\--- org.junit.jupiter:junit-jupiter-engine:5.6.0
-     +--- org.junit:junit-bom:5.6.0
-     |    +--- org.junit.jupiter:junit-jupiter-api:5.6.0 (c)
-     |    +--- org.junit.jupiter:junit-jupiter-engine:5.6.0 (c)
-     |    +--- org.junit.platform:junit-platform-engine:1.6.0 (c)
-     |    \--- org.junit.platform:junit-platform-commons:1.6.0 (c)
+\--- org.junit.jupiter:junit-jupiter-engine:5.6.2
+     +--- org.junit:junit-bom:5.6.2
+     |    +--- org.junit.jupiter:junit-jupiter-api:5.6.2 (c)
+     |    +--- org.junit.jupiter:junit-jupiter-engine:5.6.2 (c)
+     |    +--- org.junit.platform:junit-platform-engine:1.6.2 (c)
+     |    \--- org.junit.platform:junit-platform-commons:1.6.2 (c)
      +--- org.apiguardian:apiguardian-api:1.1.0
-     +--- org.junit.platform:junit-platform-engine:1.6.0
-     |    +--- org.junit:junit-bom:5.6.0 (*)
+     +--- org.junit.platform:junit-platform-engine:1.6.2
+     |    +--- org.junit:junit-bom:5.6.2 (*)
      |    +--- org.apiguardian:apiguardian-api:1.1.0
      |    +--- org.opentest4j:opentest4j:1.2.0
-     |    \--- org.junit.platform:junit-platform-commons:1.6.0
-     |         +--- org.junit:junit-bom:5.6.0 (*)
+     |    \--- org.junit.platform:junit-platform-commons:1.6.2
+     |         +--- org.junit:junit-bom:5.6.2 (*)
      |         \--- org.apiguardian:apiguardian-api:1.1.0
-     \--- org.junit.jupiter:junit-jupiter-api:5.6.0
-          +--- org.junit:junit-bom:5.6.0 (*)
+     \--- org.junit.jupiter:junit-jupiter-api:5.6.2
+          +--- org.junit:junit-bom:5.6.2 (*)
           +--- org.apiguardian:apiguardian-api:1.1.0
           +--- org.opentest4j:opentest4j:1.2.0
-          \--- org.junit.platform:junit-platform-commons:1.6.0 (*)
+          \--- org.junit.platform:junit-platform-commons:1.6.2 (*)
 
 testKotlinScriptDef - Script filename extensions discovery classpath configuration
 No dependencies
@@ -304,25 +280,25 @@ testRuntimeClasspath - Runtime classpath of compilation 'test' (target  (jvm)).
 |    +--- org.jetbrains.kotlin:kotlin-test-common:1.4.0
 |    |    \--- org.jetbrains.kotlin:kotlin-stdlib-common:1.4.0
 |    \--- org.jetbrains.kotlin:kotlin-stdlib:1.4.0 (*)
-\--- org.junit.jupiter:junit-jupiter-engine:5.6.0
-     +--- org.junit:junit-bom:5.6.0
-     |    +--- org.junit.jupiter:junit-jupiter-api:5.6.0 (c)
-     |    +--- org.junit.jupiter:junit-jupiter-engine:5.6.0 (c)
-     |    +--- org.junit.platform:junit-platform-engine:1.6.0 (c)
-     |    \--- org.junit.platform:junit-platform-commons:1.6.0 (c)
+\--- org.junit.jupiter:junit-jupiter-engine:5.6.2
+     +--- org.junit:junit-bom:5.6.2
+     |    +--- org.junit.jupiter:junit-jupiter-api:5.6.2 (c)
+     |    +--- org.junit.jupiter:junit-jupiter-engine:5.6.2 (c)
+     |    +--- org.junit.platform:junit-platform-engine:1.6.2 (c)
+     |    \--- org.junit.platform:junit-platform-commons:1.6.2 (c)
      +--- org.apiguardian:apiguardian-api:1.1.0
-     +--- org.junit.platform:junit-platform-engine:1.6.0
-     |    +--- org.junit:junit-bom:5.6.0 (*)
+     +--- org.junit.platform:junit-platform-engine:1.6.2
+     |    +--- org.junit:junit-bom:5.6.2 (*)
      |    +--- org.apiguardian:apiguardian-api:1.1.0
      |    +--- org.opentest4j:opentest4j:1.2.0
-     |    \--- org.junit.platform:junit-platform-commons:1.6.0
-     |         +--- org.junit:junit-bom:5.6.0 (*)
+     |    \--- org.junit.platform:junit-platform-commons:1.6.2
+     |         +--- org.junit:junit-bom:5.6.2 (*)
      |         \--- org.apiguardian:apiguardian-api:1.1.0
-     \--- org.junit.jupiter:junit-jupiter-api:5.6.0
-          +--- org.junit:junit-bom:5.6.0 (*)
+     \--- org.junit.jupiter:junit-jupiter-api:5.6.2
+          +--- org.junit:junit-bom:5.6.2 (*)
           +--- org.apiguardian:apiguardian-api:1.1.0
           +--- org.opentest4j:opentest4j:1.2.0
-          \--- org.junit.platform:junit-platform-commons:1.6.0 (*)
+          \--- org.junit.platform:junit-platform-commons:1.6.2 (*)
 
 testRuntimeOnly - Runtime only dependencies for compilation 'test' (target  (jvm)). (n)
 No dependencies
@@ -337,5 +313,5 @@ No dependencies
 
 A web-based, searchable dependency report is available by adding the --scan option.
 
-BUILD SUCCESSFUL in 1s
+BUILD SUCCESSFUL in 753ms
 1 actionable task: 1 executed

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.6.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/hurl-core/src/main/kotlin/com/orange/ccmd/hurl/core/ast/HurlParser.kt
+++ b/hurl-core/src/main/kotlin/com/orange/ccmd/hurl/core/ast/HurlParser.kt
@@ -263,7 +263,7 @@ internal fun HurlParser.cookieQuery(): CookieQuery? {
     val spaces = oneOrMore { space() } ?: return null
     val cookieName = quotedString() ?: return null
 
-    return CookieQuery(begin = begin, end = position, type = type, spaces = spaces, cookieName = cookieName)
+    return CookieQuery(begin = begin, end = position, type = type, spaces = spaces, expr = cookieName)
 }
 
 internal fun HurlParser.cookiesSection(): CookiesSection? {

--- a/hurl-core/src/main/kotlin/com/orange/ccmd/hurl/core/ast/Node.kt
+++ b/hurl-core/src/main/kotlin/com/orange/ccmd/hurl/core/ast/Node.kt
@@ -133,7 +133,7 @@ class CookieQuery(
     end: Position,
     type: QueryType,
     val spaces: List<Space>,
-    val cookieName: HString
+    val expr: HString
 ) : Query(begin, end, type)
 
 class CookiesSection(

--- a/hurl-core/src/main/kotlin/com/orange/ccmd/hurl/core/ast/Walker.kt
+++ b/hurl-core/src/main/kotlin/com/orange/ccmd/hurl/core/ast/Walker.kt
@@ -95,7 +95,7 @@ fun walk(visitor: Visitor, node: Node?) {
         }
         is CookieQuery -> {
             node.spaces.forEach { walk(visitor, it) }
-            walk(visitor, node.cookieName)
+            walk(visitor, node.expr)
         }
         is CookiesSection -> {
             node.lts.forEach { walk(visitor, it) }

--- a/hurl-core/src/main/kotlin/com/orange/ccmd/hurl/core/http/impl/ApacheHttpClient.kt
+++ b/hurl-core/src/main/kotlin/com/orange/ccmd/hurl/core/http/impl/ApacheHttpClient.kt
@@ -82,7 +82,7 @@ internal class ApacheHttpClient(
         }
 
         val globalConfig = RequestConfig.custom()
-            .setCookieSpec(CookieSpecs.DEFAULT)
+            .setCookieSpec(CookieSpecs.STANDARD)
             .build()
 
         builder = builder

--- a/hurl-core/src/main/kotlin/com/orange/ccmd/hurl/core/query/cookiepath/Cookie.kt
+++ b/hurl-core/src/main/kotlin/com/orange/ccmd/hurl/core/query/cookiepath/Cookie.kt
@@ -1,0 +1,111 @@
+/*
+ * Copyright (C) 2020 Orange
+ *
+ * Hurl JVM (JVM Runner for https://hurl.dev)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.orange.ccmd.hurl.core.query.cookiepath
+
+data class Cookie(
+    val name: String,
+    val value: String,
+    val expires: String? = null,
+    val maxAge: Int? = null,
+    val domain: String? = null,
+    val path: String? = null,
+    val secure: Boolean? = null,
+    val httpOnly: Boolean? = null,
+    val sameSite: String? = null,
+) {
+
+    companion object {
+
+        private const val SET_COOKIE = "set-cookie:"
+
+        /**
+         * Parse a Cookie object from a Set-Cookie HTTP header value.
+         * We can't use java.net.HttpCookie parse method because it is not
+         * supporting SameSite attribute and doesn't give access to Expires
+         * string value.
+         * This parser is a very simple parser and doesn't support all the
+         * legacy cookie formats.
+         * @param header Set-Cookie HTTP header value
+         * @return the Cookie created, or throw IllegalArgumentException if the header is not valid
+         */
+        fun fromHeader(header: String): Cookie {
+            val name: String
+            val value: String
+
+            val tokens = header.split(";")
+            if (tokens.isEmpty()) {
+                throw IllegalArgumentException("Empty cookie header string")
+            }
+
+            // there should always have at least on name-value pair;
+            // it's cookie's name
+            val nameValuePair = tokens[0]
+            val index = nameValuePair.indexOf('=')
+            if (index != -1) {
+                name = nameValuePair
+                    .substring(0, index)
+                    .trim()
+                    .trim('"', '\'')
+                value = nameValuePair
+                    .substring(index + 1)
+                    .trim()
+                    .trim('"', '\'')
+            } else {
+                // no "=" in name-value pair; it's an error
+                throw IllegalArgumentException("Invalid cookie name-value pair")
+            }
+
+            val pairAttributes = mutableMapOf<String, String>()
+            val singleAttributes = mutableListOf<String>()
+            for(i in 1 until tokens.size) {
+                val token = tokens[i]
+                val sep = token.indexOf('=')
+                if (sep != -1) {
+                    val attName = token
+                        .substring(0, sep)
+                        .trim()
+                        .toLowerCase()
+                    val attValue = token
+                        .substring(sep + 1)
+                        .trim()
+                    pairAttributes[attName] = attValue
+                } else {
+                    val attName = token
+                        .trim()
+                        .toLowerCase()
+                    singleAttributes.add(attName)
+                }
+            }
+
+            return Cookie(
+                name = name,
+                value = value,
+                expires = pairAttributes["expires"],
+                maxAge = pairAttributes["max-age"]?.toInt(),
+                domain = pairAttributes["domain"],
+                path = pairAttributes["path"],
+                secure = if ("secure" in singleAttributes) { true } else { null },
+                httpOnly = if ("httponly" in singleAttributes) { true } else { null },
+                sameSite = pairAttributes["samesite"],
+            )
+        }
+    }
+}
+

--- a/hurl-core/src/main/kotlin/com/orange/ccmd/hurl/core/query/cookiepath/CookiePath.kt
+++ b/hurl-core/src/main/kotlin/com/orange/ccmd/hurl/core/query/cookiepath/CookiePath.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2020 Orange
+ *
+ * Hurl JVM (JVM Runner for https://hurl.dev)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.orange.ccmd.hurl.core.query.cookiepath
+
+import com.orange.ccmd.hurl.core.query.InvalidQueryException
+
+class CookiePath {
+
+    companion object {
+
+        /**
+         * Evaluate a cookie-path query.
+         *
+         * @param expr cookie-path query
+         * @param headers list of HTTP headers to evaluate the query against.
+         * @return the cookie path result
+         * @throws InvalidQueryException if expr is not a valid cookie path query.
+         */
+        fun evaluate(expr: String, headers: List<Pair<String, String>>): CookiePathResult {
+            val query = try {
+                CookiePathQuery.fromString(expr)
+            } catch(e: IllegalArgumentException) {
+                throw InvalidQueryException("Invalid cookie path query $expr")
+            }
+
+            // Filter set-cookie header among all HTTP headers.
+            val cookie = try {
+                headers
+                    .filter { (name, _) -> name.toLowerCase() == "set-cookie" }
+                    .map { (_, value) -> Cookie.fromHeader(header = value) }
+                    .firstOrNull { it.name == query.name } ?: return CookiePathFailed
+            } catch (e: IllegalArgumentException) {
+                throw InvalidQueryException("Invalid set-cookie header in $headers")
+            }
+
+            val attribute = query.attribute
+            return when {
+                attribute is CookiePathAttributeValue -> CookiePathStringResult(value = cookie.value)
+                attribute is CookiePathAttributeExpires &&  cookie.expires != null -> CookiePathStringResult(value = cookie.expires)
+                attribute is CookiePathAttributeMaxAge && cookie.maxAge != null -> CookiePathNumberResult(value = cookie.maxAge)
+                attribute is CookiePathAttributeDomain && cookie.domain != null -> CookiePathStringResult(value = cookie.domain)
+                attribute is CookiePathAttributePath && cookie.path != null -> CookiePathStringResult(value = cookie.path)
+                attribute is CookiePathAttributeSecure && cookie.secure != null -> CookiePathBooleanResult(value = cookie.secure)
+                attribute is CookiePathAttributeHttpOnly && cookie.httpOnly != null -> CookiePathBooleanResult(value = cookie.httpOnly)
+                attribute is CookiePathAttributeSameSite && cookie.sameSite != null -> CookiePathStringResult(value = cookie.sameSite)
+                else -> CookiePathFailed
+            }
+
+        }
+
+    }
+}

--- a/hurl-core/src/main/kotlin/com/orange/ccmd/hurl/core/query/cookiepath/CookiePathAttribute.kt
+++ b/hurl-core/src/main/kotlin/com/orange/ccmd/hurl/core/query/cookiepath/CookiePathAttribute.kt
@@ -17,10 +17,14 @@
  *
  */
 
-package com.orange.ccmd.hurl.core.query.jsonpath
+package com.orange.ccmd.hurl.core.query.cookiepath
 
-sealed class JsonPathResult
-
-data class JsonPathOk(val result: JsonType): JsonPathResult()
-
-object JsonPathNotFound: JsonPathResult()
+sealed class CookiePathAttribute
+object CookiePathAttributeValue : CookiePathAttribute()
+object CookiePathAttributeExpires : CookiePathAttribute()
+object CookiePathAttributeMaxAge : CookiePathAttribute()
+object CookiePathAttributeDomain : CookiePathAttribute()
+object CookiePathAttributePath : CookiePathAttribute()
+object CookiePathAttributeSecure : CookiePathAttribute()
+object CookiePathAttributeHttpOnly : CookiePathAttribute()
+object CookiePathAttributeSameSite : CookiePathAttribute()

--- a/hurl-core/src/main/kotlin/com/orange/ccmd/hurl/core/query/cookiepath/CookiePathQuery.kt
+++ b/hurl-core/src/main/kotlin/com/orange/ccmd/hurl/core/query/cookiepath/CookiePathQuery.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2020 Orange
+ *
+ * Hurl JVM (JVM Runner for https://hurl.dev)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.orange.ccmd.hurl.core.query.cookiepath
+
+
+data class CookiePathQuery(val name: String, val attribute: CookiePathAttribute) {
+
+    companion object {
+
+        fun fromString(query: String): CookiePathQuery {
+
+            val start = query.indexOf("[")
+            if (start == -1) {
+                return CookiePathQuery(name = query, attribute = CookiePathAttributeValue)
+            }
+            val end = query.indexOf("]", startIndex = start+1)
+            if (end == -1) {
+                throw IllegalArgumentException("$query is not a valid cookie query")
+            }
+            val name = query.substring(0 until start)
+            val rawAttribute = query.substring((start+1) until end)
+            // Does the query contains a cookie attribute?
+            val attribute = when (rawAttribute.toLowerCase()) {
+                "value" -> CookiePathAttributeValue
+                "expires" -> CookiePathAttributeExpires
+                "max-age" -> CookiePathAttributeMaxAge
+                "domain" -> CookiePathAttributeDomain
+                "path" -> CookiePathAttributePath
+                "secure" -> CookiePathAttributeSecure
+                "httponly" -> CookiePathAttributeHttpOnly
+                "samesite" -> CookiePathAttributeSameSite
+                else -> throw IllegalArgumentException("$rawAttribute is not a valid cookie attribute")
+            }
+
+            return CookiePathQuery(name = name, attribute = attribute)
+        }
+    }
+
+}

--- a/hurl-core/src/main/kotlin/com/orange/ccmd/hurl/core/query/cookiepath/CookiePathResult.kt
+++ b/hurl-core/src/main/kotlin/com/orange/ccmd/hurl/core/query/cookiepath/CookiePathResult.kt
@@ -17,10 +17,14 @@
  *
  */
 
-package com.orange.ccmd.hurl.core.query.jsonpath
+package com.orange.ccmd.hurl.core.query.cookiepath
 
-sealed class JsonPathResult
+sealed class CookiePathResult
 
-data class JsonPathOk(val result: JsonType): JsonPathResult()
+data class CookiePathStringResult(val value: String) : CookiePathResult()
 
-object JsonPathNotFound: JsonPathResult()
+data class CookiePathNumberResult(val value: Number) : CookiePathResult()
+
+data class CookiePathBooleanResult(val value: Boolean) : CookiePathResult()
+
+object CookiePathFailed : CookiePathResult()

--- a/hurl-core/src/main/kotlin/com/orange/ccmd/hurl/core/query/jsonpath/JsonPath.kt
+++ b/hurl-core/src/main/kotlin/com/orange/ccmd/hurl/core/query/jsonpath/JsonPath.kt
@@ -33,7 +33,7 @@ class JsonPath {
                 val conf = Configuration.defaultConfiguration().addOptions(Option.ALWAYS_RETURN_LIST)
                 JsonPath.using(conf).parse(json).read(expr)
             } catch (e: PathNotFoundException) {
-                return JsonPathNotFound()
+                return JsonPathNotFound
             } catch (e: Exception) {
                 throw InvalidQueryException("$e")
             }

--- a/hurl-core/src/main/kotlin/com/orange/ccmd/hurl/core/query/xpath/XPath.kt
+++ b/hurl-core/src/main/kotlin/com/orange/ccmd/hurl/core/query/xpath/XPath.kt
@@ -28,16 +28,6 @@ import com.sun.org.apache.xpath.internal.objects.XString
 import org.jsoup.Jsoup
 
 
-sealed class XPathResult
-
-data class XPathBooleanResult(val value: Boolean) : XPathResult()
-
-data class XPathNumberResult(val value: Number) : XPathResult()
-
-data class XPathStringResult(val value: String) : XPathResult()
-
-data class XPathNodeSetResult(val size: Int): XPathResult()
-
 class XPath {
     companion object {
         fun evaluateHtml(expr: String, body: String): XPathResult {

--- a/hurl-core/src/main/kotlin/com/orange/ccmd/hurl/core/query/xpath/XPathResult.kt
+++ b/hurl-core/src/main/kotlin/com/orange/ccmd/hurl/core/query/xpath/XPathResult.kt
@@ -17,10 +17,10 @@
  *
  */
 
-package com.orange.ccmd.hurl.core.query.jsonpath
+package com.orange.ccmd.hurl.core.query.xpath
 
-sealed class JsonPathResult
-
-data class JsonPathOk(val result: JsonType): JsonPathResult()
-
-object JsonPathNotFound: JsonPathResult()
+sealed class XPathResult
+data class XPathBooleanResult(val value: Boolean) : XPathResult()
+data class XPathNumberResult(val value: Number) : XPathResult()
+data class XPathStringResult(val value: String) : XPathResult()
+data class XPathNodeSetResult(val size: Int): XPathResult()

--- a/hurl-core/src/main/kotlin/com/orange/ccmd/hurl/core/run/QueryResult.kt
+++ b/hurl-core/src/main/kotlin/com/orange/ccmd/hurl/core/run/QueryResult.kt
@@ -54,19 +54,8 @@ data class QueryObjectResult(val value: Any?): QueryResult() {
     override fun text(): String = "object <$value>"
 }
 
-class QueryNoneResult : QueryResult() {
-
+object QueryNoneResult : QueryResult() {
     override fun text(): String {
         return ""
-    }
-
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (other !is QueryNoneResult) return false
-        return true
-    }
-
-    override fun hashCode(): Int {
-        return javaClass.hashCode()
     }
 }

--- a/hurl-core/src/main/kotlin/com/orange/ccmd/hurl/core/run/Response.kt
+++ b/hurl-core/src/main/kotlin/com/orange/ccmd/hurl/core/run/Response.kt
@@ -39,7 +39,7 @@ internal fun Response.getCaptureResults(variables: VariableJar, httpResponse: Ht
 fun List<EntryStepResult>.getCaptureVariables(): Map<String, QueryResult> {
     return filterIsInstance<CaptureResult>()
         .filter { it.succeeded }
-        .map { it.variable to (it.value ?: QueryNoneResult()) }
+        .map { it.variable to (it.value ?: QueryNoneResult) }
         .toMap()
 }
 

--- a/hurl-core/src/test/kotlin/com/orange/ccmd/hurl/core/query/cookiepath/CookiePathAttributeTest.kt
+++ b/hurl-core/src/test/kotlin/com/orange/ccmd/hurl/core/query/cookiepath/CookiePathAttributeTest.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2020 Orange
+ *
+ * Hurl JVM (JVM Runner for https://hurl.dev)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.orange.ccmd.hurl.core.query.cookiepath
+
+import com.orange.ccmd.hurl.safeName
+import org.junit.jupiter.api.DynamicTest
+import org.junit.jupiter.api.TestFactory
+import org.junit.jupiter.api.assertThrows
+import kotlin.test.assertEquals
+
+internal class CookiePathAttributeTest {
+
+    @TestFactory
+    fun `create CookiePathAttribute`(): List<DynamicTest> {
+        val tests = mapOf(
+            "LSID" to CookiePathQuery(name = "LSID", attribute = CookiePathAttributeValue),
+            "LSID[Value]" to CookiePathQuery(name = "LSID", attribute = CookiePathAttributeValue),
+            "LSID[Expires]" to CookiePathQuery(name = "LSID", attribute = CookiePathAttributeExpires),
+            "LSID[Max-Age]" to CookiePathQuery(name = "LSID", attribute = CookiePathAttributeMaxAge),
+            "LSID[Domain]" to CookiePathQuery(name = "LSID", attribute = CookiePathAttributeDomain),
+            "LSID[Path]" to CookiePathQuery(name = "LSID", attribute = CookiePathAttributePath),
+            "LSID[HttpOnly]" to CookiePathQuery(name = "LSID", attribute = CookiePathAttributeHttpOnly),
+            "LSID[SameSite]" to CookiePathQuery(name = "LSID", attribute = CookiePathAttributeSameSite),
+        )
+        return tests.map { (expr, expectedValue) ->
+            DynamicTest.dynamicTest(expr.safeName()) {
+                val ret = CookiePathQuery.fromString(expr)
+                assertEquals(expectedValue, ret)
+            }
+        }
+    }
+
+    @TestFactory
+    fun `fail to create CookiePathAttribute`(): List<DynamicTest> {
+        val tests = listOf(
+            "abcd[",
+            "toto tata[]"
+        )
+        return tests.map { expr ->
+            DynamicTest.dynamicTest(expr.safeName()) {
+                assertThrows<IllegalArgumentException> { CookiePathQuery.fromString(expr) }
+            }
+        }
+    }
+
+}

--- a/hurl-core/src/test/kotlin/com/orange/ccmd/hurl/core/query/cookiepath/CookiePathTest.kt
+++ b/hurl-core/src/test/kotlin/com/orange/ccmd/hurl/core/query/cookiepath/CookiePathTest.kt
@@ -1,0 +1,147 @@
+/*
+ * Copyright (C) 2020 Orange
+ *
+ * Hurl JVM (JVM Runner for https://hurl.dev)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.orange.ccmd.hurl.core.query.cookiepath
+
+import com.orange.ccmd.hurl.safeName
+import org.junit.jupiter.api.DynamicTest
+import org.junit.jupiter.api.TestFactory
+import kotlin.test.assertEquals
+
+internal class CookiePathTest {
+
+
+    data class Test(
+        val expr: String,
+        val headers: List<Pair<String, String>>,
+        val result: CookiePathResult,
+    )
+
+    @TestFactory
+    fun `evaluate cookiepath query`(): List<DynamicTest> {
+        val tests = listOf(
+            Test(
+                expr = "LSID",
+                headers = listOf(
+                    "toto" to "tutu",
+                    "tata" to "tutu",
+                    "Set-Cookie" to "LSID=DQAAAKEaem_vYg; Expires=Wed, 13 Jan 2021 22:23:01 GMT; Secure; HttpOnly; Path=/accounts",
+                    "Set-Cookie" to "HSID=AYQEVnDKrdst; Domain=.localhost; Expires=Wed, 13 Jan 2021 22:23:01 GMT; HttpOnly; Path=/; Max-Age=2592000",
+                ),
+                result = CookiePathStringResult(value = "DQAAAKEaem_vYg")
+            ),
+            Test(
+                expr = "LSID[Value]",
+                headers = listOf(
+                    "toto" to "tutu",
+                    "tata" to "tutu",
+                    "Set-Cookie" to "LSID=DQAAAKEaem_vYg; Expires=Wed, 13 Jan 2021 22:23:01 GMT; Secure; HttpOnly; Path=/accounts",
+                    "Set-Cookie" to "HSID=AYQEVnDKrdst; Domain=.localhost; Expires=Wed, 13 Jan 2021 22:23:01 GMT; HttpOnly; Path=/; Max-Age=2592000",
+                ),
+                result = CookiePathStringResult(value = "DQAAAKEaem_vYg")
+            ),
+            Test(
+                expr = "LSID[Expires]",
+                headers = listOf(
+                    "toto" to "tutu",
+                    "tata" to "tutu",
+                    "Set-Cookie" to "LSID=DQAAAKEaem_vYg; Expires=Wed, 13 Jan 2021 22:23:01 GMT; Secure; HttpOnly; Path=/accounts",
+                    "Set-Cookie" to "HSID=AYQEVnDKrdst; Domain=.localhost; Expires=Wed, 13 Jan 2021 22:23:01 GMT; HttpOnly; Path=/; Max-Age=2592000",
+                ),
+                result = CookiePathStringResult(value = "Wed, 13 Jan 2021 22:23:01 GMT")
+            ),
+            Test(
+                expr = "HSID[Max-Age]",
+                headers = listOf(
+                    "toto" to "tutu",
+                    "tata" to "tutu",
+                    "Set-Cookie" to "LSID=DQAAAKEaem_vYg; Expires=Wed, 13 Jan 2021 22:23:01 GMT; Secure; HttpOnly; Path=/accounts",
+                    "Set-Cookie" to "HSID=AYQEVnDKrdst; Domain=.localhost; Expires=Wed, 13 Jan 2021 22:23:01 GMT; HttpOnly; Path=/; Max-Age=2592000",
+                ),
+                result = CookiePathNumberResult(value = 2592000)
+            ),
+            Test(
+                expr = "LSID[Domain]",
+                headers = listOf(
+                    "toto" to "tutu",
+                    "tata" to "tutu",
+                    "Set-Cookie" to "LSID=DQAAAKEaem_vYg; Expires=Wed, 13 Jan 2021 22:23:01 GMT; Secure; HttpOnly; Path=/accounts",
+                    "Set-Cookie" to "HSID=AYQEVnDKrdst; Domain=.localhost; Expires=Wed, 13 Jan 2021 22:23:01 GMT; HttpOnly; Path=/; Max-Age=2592000",
+                ),
+                result = CookiePathFailed
+            ),
+            Test(
+                expr = "HSID[Domain]",
+                headers = listOf(
+                    "toto" to "tutu",
+                    "tata" to "tutu",
+                    "Set-Cookie" to "LSID=DQAAAKEaem_vYg; Expires=Wed, 13 Jan 2021 22:23:01 GMT; Secure; HttpOnly; Path=/accounts",
+                    "Set-Cookie" to "HSID=AYQEVnDKrdst; Domain=.localhost; Expires=Wed, 13 Jan 2021 22:23:01 GMT; HttpOnly; Path=/; Max-Age=2592000",
+                ),
+                result = CookiePathStringResult(value = ".localhost")
+            ),
+            Test(
+                expr = "LSID[Path]",
+                headers = listOf(
+                    "toto" to "tutu",
+                    "tata" to "tutu",
+                    "Set-Cookie" to "LSID=DQAAAKEaem_vYg; Expires=Wed, 13 Jan 2021 22:23:01 GMT; Secure; HttpOnly; Path=/accounts",
+                    "Set-Cookie" to "HSID=AYQEVnDKrdst; Domain=.localhost; Expires=Wed, 13 Jan 2021 22:23:01 GMT; HttpOnly; Path=/; Max-Age=2592000",
+                ),
+                result = CookiePathStringResult(value = "/accounts")
+            ),
+            Test(
+                expr = "LSID[Secure]",
+                headers = listOf(
+                    "toto" to "tutu",
+                    "tata" to "tutu",
+                    "Set-Cookie" to "LSID=DQAAAKEaem_vYg; Expires=Wed, 13 Jan 2021 22:23:01 GMT; Secure; HttpOnly; Path=/accounts",
+                    "Set-Cookie" to "HSID=AYQEVnDKrdst; Domain=.localhost; Expires=Wed, 13 Jan 2021 22:23:01 GMT; HttpOnly; Path=/; Max-Age=2592000",
+                ),
+                result = CookiePathBooleanResult(value = true)
+            ),
+            Test(
+                expr = "LSID[HttpOnly]",
+                headers = listOf(
+                    "toto" to "tutu",
+                    "tata" to "tutu",
+                    "Set-Cookie" to "LSID=DQAAAKEaem_vYg; Expires=Wed, 13 Jan 2021 22:23:01 GMT; Secure; HttpOnly; Path=/accounts",
+                    "Set-Cookie" to "HSID=AYQEVnDKrdst; Domain=.localhost; Expires=Wed, 13 Jan 2021 22:23:01 GMT; HttpOnly; Path=/; Max-Age=2592000",
+                ),
+                result = CookiePathBooleanResult(value = true)
+            ),
+            Test(
+                expr = "LSID[SameSite]",
+                headers = listOf(
+                    "toto" to "tutu",
+                    "tata" to "tutu",
+                    "Set-Cookie" to "LSID=DQAAAKEaem_vYg; Expires=Wed, 13 Jan 2021 22:23:01 GMT; Secure; HttpOnly; Path=/accounts",
+                    "Set-Cookie" to "HSID=AYQEVnDKrdst; Domain=.localhost; Expires=Wed, 13 Jan 2021 22:23:01 GMT; HttpOnly; Path=/; Max-Age=2592000",
+                ),
+                result = CookiePathFailed
+            ),
+        )
+        return tests.map { (expr, headers, expectedValue) ->
+            DynamicTest.dynamicTest(expr.safeName()) {
+                val ret = CookiePath.evaluate(expr = expr, headers = headers)
+                assertEquals(expectedValue, ret)
+            }
+        }
+    }
+}

--- a/hurl-core/src/test/kotlin/com/orange/ccmd/hurl/core/query/cookiepath/CookieTest.kt
+++ b/hurl-core/src/test/kotlin/com/orange/ccmd/hurl/core/query/cookiepath/CookieTest.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2020 Orange
+ *
+ * Hurl JVM (JVM Runner for https://hurl.dev)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.orange.ccmd.hurl.core.query.cookiepath
+
+import com.orange.ccmd.hurl.safeName
+import org.junit.jupiter.api.DynamicTest
+import org.junit.jupiter.api.TestFactory
+import kotlin.test.assertEquals
+
+internal class CookieTest {
+
+    @TestFactory
+    fun `create cookie successfully`(): List<DynamicTest> {
+        val tests = mapOf(
+            "sessionId=38afes7a8"
+                    to
+                    Cookie(name = "sessionId", value = "38afes7a8"),
+            "id=a3fWa; Expires=Wed, 21 Oct 2015 07:28:00 GMT"
+                    to
+                    Cookie(name = "id", value = "a3fWa", expires = "Wed, 21 Oct 2015 07:28:00 GMT"),
+            "qwerty=219ffwef9w0f; Domain=somecompany.co.uk"
+                    to
+                    Cookie(name = "qwerty", value = "219ffwef9w0f", domain = "somecompany.co.uk"),
+            "SSID=Ap4PGTEq; Domain=.localhost; Expires=Wed, 13 Jan 2021 22:23:01 GMT; Secure; HttpOnly; Path=/; SameSite=Lax"
+                    to
+                    Cookie(
+                        name = "SSID",
+                        value = "Ap4PGTEq",
+                        domain = ".localhost",
+                        expires = "Wed, 13 Jan 2021 22:23:01 GMT",
+                        secure = true,
+                        httpOnly = true,
+                        path = "/",
+                        sameSite = "Lax",
+                    ),
+        )
+        return tests.map { (header, expectedValue) ->
+            DynamicTest.dynamicTest(header.safeName()) {
+                val ret = Cookie.fromHeader(header)
+                assertEquals(expectedValue, ret)
+            }
+        }
+    }
+
+
+}

--- a/hurl-core/src/test/kotlin/com/orange/ccmd/hurl/core/query/jsonpath/JsonPathTest.kt
+++ b/hurl-core/src/test/kotlin/com/orange/ccmd/hurl/core/query/jsonpath/JsonPathTest.kt
@@ -17,11 +17,8 @@
  *
  */
 
-package com.orange.ccmd.hurl.core.query
+package com.orange.ccmd.hurl.core.query.jsonpath
 
-import com.orange.ccmd.hurl.core.query.jsonpath.JsonPath
-import com.orange.ccmd.hurl.core.query.jsonpath.JsonPathOk
-import com.orange.ccmd.hurl.core.query.jsonpath.toJson
 import com.orange.ccmd.hurl.safeName
 import org.junit.jupiter.api.DynamicTest
 import org.junit.jupiter.api.TestFactory

--- a/hurl-core/src/test/kotlin/com/orange/ccmd/hurl/core/query/xpath/XPathTest.kt
+++ b/hurl-core/src/test/kotlin/com/orange/ccmd/hurl/core/query/xpath/XPathTest.kt
@@ -17,13 +17,9 @@
  *
  */
 
-package com.orange.ccmd.hurl.core.query
+package com.orange.ccmd.hurl.core.query.xpath
 
-import com.orange.ccmd.hurl.core.query.xpath.XPath
-import com.orange.ccmd.hurl.core.query.xpath.XPathBooleanResult
-import com.orange.ccmd.hurl.core.query.xpath.XPathNodeSetResult
-import com.orange.ccmd.hurl.core.query.xpath.XPathNumberResult
-import com.orange.ccmd.hurl.core.query.xpath.XPathStringResult
+import com.orange.ccmd.hurl.core.query.InvalidQueryException
 import com.orange.ccmd.hurl.safeName
 import org.junit.jupiter.api.DynamicTest
 import org.junit.jupiter.api.Test

--- a/hurl-core/src/test/kotlin/com/orange/ccmd/hurl/core/run/QueryEvalTest.kt
+++ b/hurl-core/src/test/kotlin/com/orange/ccmd/hurl/core/run/QueryEvalTest.kt
@@ -96,7 +96,7 @@ class QueryEvalTest {
             body = ByteArray(0)
         )
         val expected = QueryStringResult("a3fWa")
-        assertEquals(expected, query.eval(response))
+        assertEquals(expected, query.eval(response = response, variables = VariableJar()))
     }
 
     @Test
@@ -116,8 +116,8 @@ class QueryEvalTest {
             mimeType = "text/plain",
             body = ByteArray(0)
         )
-        val expected = QueryNoneResult()
-        assertEquals(expected, query.eval(response))
+        val expected = QueryNoneResult
+        assertEquals(expected, query.eval(response = response, variables = VariableJar()))
     }
 
     @Test
@@ -194,7 +194,7 @@ class QueryEvalTest {
         "$.{{field}}" to QueryBooleanResult(false),
         "$.errors" to QueryListResult(size = 2),
         "$.warnings" to QueryListResult(size = 0),
-        "$.toto" to QueryNoneResult(),
+        "$.toto" to QueryNoneResult,
         "$.errors[0].id" to QueryStringResult("error1"),
         "$.errors[0]['id']" to QueryStringResult("error1"),
         "$.count" to QueryNumberResult(13.5)

--- a/integration/tests/cookies.hurl
+++ b/integration/tests/cookies.hurl
@@ -49,6 +49,26 @@ header "Set-Cookie" contains "Max-Age=0"   # TODO replace by cookie query
 
 
 
+GET http://localhost:8000/cookies/set
+HTTP/1.0 200
+Set-Cookie: LSID=DQAAAKEaem_vYg; Expires=Wed, 13 Jan 2021 22:23:01 GMT; Secure; HttpOnly; Path=/accounts
+Set-Cookie: HSID=AYQEVnDKrdst; Domain=.localhost; Expires=Wed, 13 Jan 2021 22:23:01 GMT; HttpOnly; Path=/
+Set-Cookie: SSID=Ap4PGTEq; Domain=.localhost; Expires=Wed, 13 Jan 2021 22:23:01 GMT; Secure; HttpOnly; Path=/
+
+[Asserts]
+header "Set-Cookie" countEquals 3
+cookie "LSID" equals "DQAAAKEaem_vYg"
+cookie "LSID[Value]" equals "DQAAAKEaem_vYg"
+cookie "LSID[Expires]" exists
+cookie "LSID[Expires]" equals "Wed, 13 Jan 2021 22:23:01 GMT"
+cookie "LSID[Max-Age]" not exists
+cookie "LSID[Domain]" not exists
+cookie "LSID[Path]" equals "/accounts"
+cookie "LSID[Secure]" equals true
+cookie "LSID[HttpOnly]" equals true
+cookie "LSID[SameSite]" not exists
+
+
 
 
 

--- a/integration/tests/cookies.py
+++ b/integration/tests/cookies.py
@@ -74,3 +74,19 @@ def set_session_cookie2_valuea_subdomain2():
     resp = make_response()
     resp.set_cookie('cookie2', 'valueA', domain='orange.localhost')
     return resp
+
+
+# Set-Cookie: LSID=; Path=/accounts; Expires=Wed, 13 Jan 2021 22:23:01 GMT; Secure; HttpOnly
+# Set-Cookie: HSID=AYQEVn…DKrdst; Domain=.localhost; Path=/; Expires=Wed, 13 Jan 2021 22:23:01 GMT; HttpOnly
+# Set-Cookie: SSID=Ap4P…GTEq; Domain=.localhost; Path=/; Expires=Wed, 13 Jan 2021 22:23:01 GMT; Secure; HttpOnly
+@app.route("/cookies/set")
+def set_cookies():
+    resp = make_response()
+    resp.set_cookie('LSID', 'DQAAAKEaem_vYg', path='/accounts', secure=True, httponly=True, expires='Wed, 13 Jan 2021 22:23:01 GMT')
+    resp.set_cookie('HSID', 'AYQEVnDKrdst', domain='.localhost', path='/', expires='Wed, 13 Jan 2021 22:23:01 GMT', httponly=True)
+    resp.set_cookie('SSID', 'Ap4PGTEq', domain='.localhost', path='/', expires='Wed, 13 Jan 2021 22:23:01 GMT', secure=True, httponly=True)
+    return resp
+
+
+
+


### PR DESCRIPTION
Add support for cookie query:

```
GET http://localhost:8000/cookies/set
HTTP/1.0 200
Set-Cookie: LSID=DQAAAKEaem_vYg; Expires=Wed, 13 Jan 2021 22:23:01 GMT; Secure; HttpOnly; Path=/accounts
Set-Cookie: HSID=AYQEVnDKrdst; Domain=.localhost; Expires=Wed, 13 Jan 2021 22:23:01 GMT; HttpOnly; Path=/
Set-Cookie: SSID=Ap4PGTEq; Domain=.localhost; Expires=Wed, 13 Jan 2021 22:23:01 GMT; Secure; HttpOnly; Path=/

[Asserts]
header "Set-Cookie" countEquals 3
cookie "LSID" equals "DQAAAKEaem_vYg"
cookie "LSID[Value]" equals "DQAAAKEaem_vYg"
cookie "LSID[Expires]" exists
cookie "LSID[Expires]" equals "Wed, 13 Jan 2021 22:23:01 GMT"
cookie "LSID[Max-Age]" not exists
cookie "LSID[Domain]" not exists
cookie "LSID[Path]" equals "/accounts"
cookie "LSID[Secure]" equals true
cookie "LSID[HttpOnly]" equals true
cookie "LSID[SameSite]" not exists
``