### PR TITLE
Add default content type for some file extension in multipart-form-datas.

### DIFF
--- a/hurl-core/src/main/kotlin/com/orange/ccmd/hurl/core/http/Mime.kt
+++ b/hurl-core/src/main/kotlin/com/orange/ccmd/hurl/core/http/Mime.kt
@@ -1,0 +1,34 @@
+package com.orange.ccmd.hurl.core.http
+
+import java.io.File
+
+/**
+ * Helper class for MIME type.
+ */
+class Mime {
+    companion object {
+
+        /**
+         * Returns the content type for a list of know extension, given ea [fileName].
+         * @param fileName input filename
+         * @return a content type string if knows, null otherswise.
+         */
+        fun getContentType(fileName: String): String? {
+            val ext = File(fileName).extension
+            val contentTypes = mapOf(
+                "gif" to "image/gif",
+                "jpg" to "image/jpeg",
+                "jpeg" to "image/jpeg",
+                "png" to "image/png",
+                "svg" to "image/svg+xml",
+                "txt" to "text/plain",
+                "htm" to "text/html",
+                "html" to "text/html",
+                "pdf" to "application/pdf",
+                "xml" to "application/xml",
+            )
+            return contentTypes[ext]
+        }
+
+    }
+}

--- a/hurl-core/src/main/kotlin/com/orange/ccmd/hurl/core/http/impl/ApacheHttpClient.kt
+++ b/hurl-core/src/main/kotlin/com/orange/ccmd/hurl/core/http/impl/ApacheHttpClient.kt
@@ -232,10 +232,11 @@ internal fun HttpRequest.prepareBody(builder: RequestBuilder) = when {
                 // > the file data SHOULD be labeled with an appropriate media type, if
                 // > known, or "application/octet-stream".
                 is FileFormData -> {
-                    val contentType = if (it.contentType != null) {
-                        ContentType.create(it.contentType)
-                    } else {
-                        APPLICATION_OCTET_STREAM
+                    val knownContentType = Mime.getContentType(fileName = it.fileName)
+                    val contentType = when {
+                        it.contentType != null -> ContentType.create(it.contentType)
+                        knownContentType != null -> ContentType.create(knownContentType)
+                        else -> APPLICATION_OCTET_STREAM
                     }
                     entityBuilder.addBinaryBody(it.name, it.value, contentType, it.fileName)
                 }

--- a/hurl-core/src/main/kotlin/com/orange/ccmd/hurl/core/http/impl/ApacheHttpClient.kt
+++ b/hurl-core/src/main/kotlin/com/orange/ccmd/hurl/core/http/impl/ApacheHttpClient.kt
@@ -29,6 +29,7 @@ import com.orange.ccmd.hurl.core.http.HttpRequest
 import com.orange.ccmd.hurl.core.http.HttpResponse
 import com.orange.ccmd.hurl.core.http.HttpResult
 import com.orange.ccmd.hurl.core.http.JsonRequestBody
+import com.orange.ccmd.hurl.core.http.Mime
 import com.orange.ccmd.hurl.core.http.Proxy
 import com.orange.ccmd.hurl.core.http.TextFormData
 import com.orange.ccmd.hurl.core.http.USER_AGENT

--- a/hurl-core/src/main/kotlin/com/orange/ccmd/hurl/core/utils/File.kt
+++ b/hurl-core/src/main/kotlin/com/orange/ccmd/hurl/core/utils/File.kt
@@ -1,0 +1,6 @@
+package com.orange.ccmd.hurl.core.utils
+
+import java.io.File
+
+val File.extension: String
+    get() = name.substringAfterLast('.', "")

--- a/integration/tests/multipart_form_data.hurl
+++ b/integration/tests/multipart_form_data.hurl
@@ -3,8 +3,8 @@ POST http://localhost:8000/multipart-form-data
 [MultipartFormData]
 key1: value1
 upload1: file,hello.txt;
-upload2: file,hello.html; text/html
-upload3: file,hello.txt; text/plain
+upload2: file,hello.html;
+upload3: file,hello.txt; text/html
 
 HTTP/1.0 200
 

--- a/integration/tests/multipart_form_data.py
+++ b/integration/tests/multipart_form_data.py
@@ -9,7 +9,7 @@ def multipart_form_data():
 
     upload1 = request.files['upload1']
     assert upload1.filename == 'hello.txt'
-    assert upload1.content_type == 'application/octet-stream'
+    assert upload1.content_type == 'text/plain'
     assert upload1.read() == b'Hello World!'
 
     upload2 = request.files['upload2']
@@ -19,7 +19,7 @@ def multipart_form_data():
 
     upload3 = request.files['upload3']
     assert upload3.filename == 'hello.txt'
-    assert upload3.content_type == 'text/plain'
+    assert upload3.content_type == 'text/html'
     assert upload3.read() == b'Hello World!'
 
     return ''


### PR DESCRIPTION
Set the default content type according to https://github.com/Orange-OpenSource/hurl/issues/3.